### PR TITLE
Refactoring cb-event-duplicator for Python 3 support, importability a…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ nosetests.xml
 
 # IDE exclusions
 .idea
+
+# virtualenv exclusions
+.env/
+.p2env/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include *

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Extract events from one Carbon Black server and send them to another server - us
 Note that since this tool works at the SOLR level (underneath the supported API), it does *not* support Carbon Black
 clusters at this time.
 
+Note that you may want to modify the Event Store configuration on your Carbon Black servers so that process documents
+are not purged.  See the section of the User Guide which discusses MaxEventStoreSizeInDocs, MaxEventStoreDays,
+MaxEventStoreSizeInMB and MaxEventStoreSizeInPercent.  The default value for the Event Store's retention
+policy is set MaxEventStoreDays=30.
+
+
 ## Installation Quickstart
 
 If you want to use this on a Carbon Black server, or any other CentOS 6.x, 7.x or Ubuntu based 64 bit Linux platform, 
@@ -26,6 +32,9 @@ That will place the cb-event-duplicator binary in your local user's "bin" direct
 
 ### Source Installation
 
+You must first install the postgres client via yum install postgresql-devel on CentOS/RedHat systems or
+sudo apt-get install postgresql postgresql-contrib on Ubuntu and other Debian based platforms
+
 If you want to install from source, you can install it via:
 
 ```
@@ -33,9 +42,6 @@ python setup.py install
 ```
 
 Once the package is installed, you will have a new script in your $PATH: `cb-event-duplicator`.
-
-If you want to enable the optional SSH support to transparently
-send or receive events via an SSH tunnel to another Cb server, then you will have to install the Python `paramiko` package.
 
 ## Usage
 
@@ -52,10 +58,12 @@ positional arguments:
   source                Data source - can be a pathname (/tmp/blah), a URL
                         referencing a zip package
                         (http://my.server.com/package.zip), the local Cb
-                        server (local), or a remote Cb server
+                        server (local), or a remote Cb server, omit the colon and subsequent
+                        port number to default to port 22
                         (root@cb5.server:2202)
   destination           Data destination - can be a filepath (/tmp/blah), the
-                        local Cb server (local), or a remote Cb server
+                        local Cb server (local), or a remote Cb server, omit the colon and subsequent
+                        port number to default to port 22
                         (root@cb5.server:2202)
 
 optional arguments:

--- a/cbopensource/__init__.py
+++ b/cbopensource/__init__.py
@@ -1,1 +1,2 @@
+from __future__ import absolute_import, division, print_function
 __author__ = 'jgarman'

--- a/cbopensource/tools/__init__.py
+++ b/cbopensource/tools/__init__.py
@@ -1,1 +1,2 @@
+from __future__ import absolute_import, division, print_function
 __author__ = 'jgarman'

--- a/cbopensource/tools/eventduplicator/__init__.py
+++ b/cbopensource/tools/eventduplicator/__init__.py
@@ -1,5 +1,6 @@
-__author__ = 'jgarman'
-
+from __future__ import absolute_import, division, print_function
 import logging
+
+__author__ = 'jgarman'
 
 main_log = logging.getLogger(__name__)

--- a/cbopensource/tools/eventduplicator/file_endpoint.py
+++ b/cbopensource/tools/eventduplicator/file_endpoint.py
@@ -1,19 +1,21 @@
-__author__ = 'jgarman'
-
+from __future__ import absolute_import, division, print_function
 import os
 import hashlib
-from utils import get_process_id, json_encode
+from cbopensource.tools.eventduplicator.utils import get_process_id, json_encode
 import json
+import codecs
 from collections import defaultdict
 import logging
 
+__author__ = 'jgarman'
 
 log = logging.getLogger(__name__)
 
 
 def get_process_path(proc_guid):
-    key = hashlib.md5(str(proc_guid)).hexdigest()
+    key = hashlib.md5(str(proc_guid).encode('utf8')).hexdigest()
     return os.path.join(key[:2].upper(), '%s.json' % proc_guid)
+
 
 def get_binary_path(md5sum):
     return os.path.join(md5sum[:2].upper(), '%s.json' % md5sum.lower())
@@ -22,9 +24,10 @@ def get_binary_path(md5sum):
 class FileInputSource(object):
     def __init__(self, pathname):
         self.pathname = pathname
+        self.reader = codecs.getreader("utf-8")
 
     def get_version(self):
-        return open(os.path.join(self.pathname, 'VERSION'), 'rb').read()
+        return open(os.path.join(self.pathname, 'VERSION'), 'r').read()
 
     def get_process_docs(self, query_filter=None):
         # TODO: the query_filter is a code smell... we should push the traversal code into the Source?
@@ -33,39 +36,39 @@ class FileInputSource(object):
 
         for root, dirs, files in os.walk(os.path.join(self.pathname, 'procs')):
             for fn in files:
-                yield json.load(open(os.path.join(root, fn), 'rb'))
+                yield json.load(self.reader(open(os.path.join(root, fn), 'rb')))
 
     def get_feed_doc(self, feed_key):
         pathname = os.path.join(self.pathname, 'feeds', '%s.json' % feed_key)
         try:
-            return json.load(open(pathname, 'rb'))
+            return json.load(self.reader(open(pathname, 'rb')))
         except Exception as e:
-            log.warning("Could not open feed document: %s" % pathname)
+            log.warning("Could not open feed document: %s - %s" % (pathname, str(e)))
             return None
 
     def get_feed_metadata(self, feed_id):
         pathname = os.path.join(self.pathname, 'feeds', '%s.json' % feed_id)
         try:
-            return json.load(open(pathname, 'rb'))
+            return json.load(self.reader(open(pathname, 'rb')))
         except Exception as e:
-            log.warning("Could not open feed metadata: %s" % pathname)
+            log.warning("Could not open feed metadata: %s - %s" % (pathname, str(e)))
             return None
 
     def get_binary_doc(self, md5sum):
         md5sum = md5sum.lower()
         pathname = os.path.join(self.pathname, 'binaries', get_binary_path(md5sum))
         try:
-            return json.load(open(pathname, 'rb'))
+            return json.load(self.reader(open(pathname, 'rb')))
         except Exception as e:
-            log.warning("Could not open binary document: %s" % pathname)
+            log.warning("Could not open binary document: %s - %s" % (pathname, str(e)))
             return None
 
     def get_sensor_doc(self, sensor_id):
         pathname = os.path.join(self.pathname, 'sensors', '%d.json' % sensor_id)
         try:
-            return json.load(open(os.path.join(self.pathname, 'sensors', '%d.json' % sensor_id), 'rb'))
+            return json.load(open(os.path.join(self.pathname, 'sensors', '%d.json' % sensor_id), 'r'))
         except Exception as e:
-            log.warning("Could not open sensor document: %s" % pathname)
+            log.warning("Could not open sensor document: %s - %s" % (pathname, str(e)))
             return None
 
     def connection_name(self):
@@ -78,52 +81,51 @@ class FileInputSource(object):
 class FileOutputSink(object):
     def __init__(self, pathname):
         self.pathname = pathname
-        os.makedirs(pathname, 0755)
+        os.makedirs(pathname, 0o755)
 
-        os.makedirs(os.path.join(pathname, 'procs'), 0755)
-        os.makedirs(os.path.join(pathname, 'binaries'), 0755)
-        os.makedirs(os.path.join(pathname, 'sensors'), 0755)
-        os.makedirs(os.path.join(pathname, 'feeds'), 0755)
+        os.makedirs(os.path.join(pathname, 'procs'), 0o755)
+        os.makedirs(os.path.join(pathname, 'binaries'), 0o755)
+        os.makedirs(os.path.join(pathname, 'sensors'), 0o755)
+        os.makedirs(os.path.join(pathname, 'feeds'), 0o755)
 
         # TODO: only create the directories we need
         for dirname in ['procs', 'binaries']:
-            for segment in ['%02X' % x for x in range(0,256)]:
-                os.makedirs(os.path.join(pathname, dirname, segment), 0755)
+            for segment in ['%02X' % x for x in range(0, 256)]:
+                os.makedirs(os.path.join(pathname, dirname, segment), 0o755)
 
         self.written_docs = defaultdict(int)
         self.new_metadata = defaultdict(list)
-
 
     def output_process_doc(self, doc_content):
         proc_guid = get_process_id(doc_content)
         pathname = os.path.join(self.pathname, 'procs', get_process_path(proc_guid))
         if os.path.exists(pathname):
             log.warning('process %s already existed, writing twice' % proc_guid)
-        open(os.path.join(self.pathname, 'procs', get_process_path(proc_guid)), 'wb').write(json_encode(doc_content))
+        open(os.path.join(self.pathname, 'procs', get_process_path(proc_guid)), 'w').write(json_encode(doc_content))
         self.written_docs['proc'] += 1
 
     def output_binary_doc(self, doc_content):
         md5sum = doc_content.get('md5').lower()
-        open(os.path.join(self.pathname, 'binaries', get_binary_path(md5sum)), 'wb').write(json_encode(doc_content))
+        open(os.path.join(self.pathname, 'binaries', get_binary_path(md5sum)), 'w').write(json_encode(doc_content))
         self.written_docs['binary'] += 1
 
     def output_sensor_info(self, doc_content):
-        open(os.path.join(self.pathname, 'sensors', '%s.json' % doc_content['sensor_info']['id']), 'wb').\
+        open(os.path.join(self.pathname, 'sensors', '%s.json' % doc_content['sensor_info']['id']), 'w').\
             write(json_encode(doc_content))
         self.new_metadata['sensor'].append(doc_content['sensor_info']['computer_name'])
 
     def output_feed_doc(self, doc_content):
-        open(os.path.join(self.pathname, 'feeds', '%s:%s.json' % (doc_content['feed_name'], doc_content['id'])), 'wb').\
+        open(os.path.join(self.pathname, 'feeds', '%s:%s.json' % (doc_content['feed_name'], doc_content['id'])), 'w').\
             write(json_encode(doc_content))
         self.written_docs['feed'] += 1
 
     def output_feed_metadata(self, doc_content):
-        open(os.path.join(self.pathname, 'feeds', '%s.json' % (doc_content['id'],)), 'wb').\
+        open(os.path.join(self.pathname, 'feeds', '%s.json' % (doc_content['id'],)), 'w').\
             write(json_encode(doc_content))
         self.new_metadata['feed'].append(doc_content['name'])
 
     def set_data_version(self, version):
-        open(os.path.join(self.pathname, 'VERSION'), 'wb').write(version)
+        open(os.path.join(self.pathname, 'VERSION'), 'w').write(version)
         return True
 
     def cleanup(self):

--- a/cbopensource/tools/eventduplicator/ssh_connection.py
+++ b/cbopensource/tools/eventduplicator/ssh_connection.py
@@ -86,20 +86,17 @@ class SSHConnection(object):
         self.session = requests.Session()
 
         connected = False
-        password = None
+        password = ''
         while not connected:
             try:
                 self.ssh_connection.connect(hostname=hostname, username=username, port=port, look_for_keys=False,
-                                            password=password, timeout=2.0, banner_timeout=2.0, allow_agent=False)
+                                            password=password, timeout=2.0, banner_timeout=2.0, allow_agent=True)
                 connected = True
             except paramiko.AuthenticationException:
                 password = password_callback(self.name)
             except paramiko.SSHException as e:
-                if str(e) == 'No authentication methods available':
-                    password = password_callback(self.name)
-                else:
-                    log.error("Error logging into %s: %s" % (self.name, str(e)))
-                    raise
+                log.error("Error logging into %s: %s" % (self.name, str(e)))
+                raise
             except socket.error as e:
                 log.error("Error connecting to %s: %s" % (self.name, str(e)))
                 raise

--- a/cbopensource/tools/eventduplicator/transporter.py
+++ b/cbopensource/tools/eventduplicator/transporter.py
@@ -1,11 +1,13 @@
-__author__ = 'jgarman'
-
+from __future__ import absolute_import, division, print_function
 import logging
 import datetime
-from utils import get_process_id, get_parent_process_id, split_process_id
+from cbopensource.tools.eventduplicator.utils import get_process_id, get_parent_process_id
 import sys
 
+__author__ = 'jgarman'
+
 log = logging.getLogger(__name__)
+
 
 class Transporter(object):
     def __init__(self, input_source, output_sink, tree=False):
@@ -27,7 +29,7 @@ class Transporter(object):
 
     def output_process_doc(self, doc):
         for munger in self.mungers:
-            doc = munger.munge_document('proc', doc)
+            doc = munger.munge_document(doc)
 
         sys.stdout.write('%-70s\r' % ("Uploading process %s..." % get_process_id(doc)))
         sys.stdout.flush()
@@ -36,7 +38,7 @@ class Transporter(object):
 
     def output_feed_doc(self, doc):
         for munger in self.mungers:
-            doc = munger.munge_document('feed', doc)
+            doc = munger.munge_document(doc)
 
         # check if we have seen this feed_id before
         feed_id = doc['feed_id']
@@ -52,7 +54,7 @@ class Transporter(object):
     def output_binary_doc(self, doc):
         for munger in self.mungers:
             # note that the mungers are mutating the data in place, anyway.
-            doc = munger.munge_document('binary', doc)
+            doc = munger.munge_document(doc)
 
         sys.stdout.write('%-70s\r' % ("Uploading binary %s..." % doc['md5']))
         sys.stdout.flush()
@@ -62,7 +64,7 @@ class Transporter(object):
     def output_sensor_info(self, doc):
         for munger in self.mungers:
             # note that the mungers are mutating the data in place, anyway.
-            doc['sensor_info'] = munger.munge_document('sensor', doc['sensor_info'])
+            doc['sensor_info'] = munger.munge_document(doc['sensor_info'])
 
         self.output.output_sensor_info(doc)
 
@@ -159,76 +161,73 @@ class Transporter(object):
         self.seen_feeds |= feed_lookup
         return retval
 
-    def generate_fake_sensor(self, sensor_id):
-        sensor = {  'build_info':
-                        {'architecture': 32,
-                        'build_version': 50106,
-                        'id': 9,
-                        'installer_avail': True,
-                        'major_version': 5,
-                        'minor_version': 0,
-                        'patch_version': 0,
-                        'upgrader_avail': True,
-                        'version_string': '005.000.000.50106'},
-                    'os_info':
-                        {'architecture': 32,
-                         'display_string': 'Windows 7 Ultimate Edition Service Pack 1, 32-bit',
-                         'id': 1,
-                         'major_version': 6,
-                         'minor_version': 1,
-                         'os_type': 1,
-                         'product_type': 1,
-                         'service_pack': 'Service Pack 1',
-                         'suite_mask': 256},
-                    'sensor_info':
-                        {'boot_id': 17L,
-                         'build_id': 9,
-                         'clock_delta': 2654783L,
-                         'computer_dns_name': 'sensor%d' % sensor_id ,
-                         'computer_name': 'sensor%d' % sensor_id,
-                         'computer_sid': 'S-1-5-21-2002419555-2189168078-3210101973',
-                         'cookie': 1962833602,
-                         'display': True,
-                         'emet_dump_flags': None,
-                         'emet_exploit_action': None,
-                         'emet_is_gpo': False,
-                         'emet_process_count': 0,
-                         'emet_report_setting': None,
-                         'emet_telemetry_path': None,
-                         'emet_version': None,
-                         'event_log_flush_time': None,
-                         'group_id': 1,
-                         'id': sensor_id,
-                         'last_checkin_time': datetime.datetime(2015, 6, 30, 6, 9, 15, 570570),
-                         'last_update': datetime.datetime(2015, 6, 30, 6, 9, 18, 170552),
-                         'license_expiration': datetime.datetime(1990, 1, 1, 0, 0),
-                         'network_adapters': '192.168.10.241,000c19e962f6|192.168.10.5,000c23b742dc|',
-                         'network_isolation_enabled': False,
-                         'next_checkin_time': datetime.datetime(2015, 6, 30, 6, 9, 45, 564598),
-                         'node_id': 0,
-                         'notes': None,
-                         'num_eventlog_bytes': 400L,
-                         'num_storefiles_bytes': 10304408L,
-                         'os_environment_id': 1,
-                         'parity_host_id': 2L,
-                         'physical_memory_size': 1073209344L,
-                         'power_state': 0,
-                         'registration_time': datetime.datetime(2015, 1, 23, 15, 39, 54, 911720),
-                         'restart_queued': False,
-                         'sensor_health_message': 'Healthy',
-                         'sensor_health_status': 100,
-                         'sensor_uptime': 2976455L,
-                         'session_token': 0,
-                         'supports_2nd_gen_modloads': False,
-                         'supports_cblr': True,
-                         'supports_isolation': True,
-                         'systemvolume_free_size': 49276923904L,
-                         'systemvolume_total_size': 64422408192L,
-                         'uninstall': False,
-                         'uninstalled': None,
-                         'uptime': 340776L}}
+    @staticmethod
+    def generate_fake_sensor(sensor_id):
+        sensor = {'build_info': {'architecture': 32,
+                                 'build_version': 50106,
+                                 'id': 9,
+                                 'installer_avail': True,
+                                 'major_version': 5,
+                                 'minor_version': 0,
+                                 'patch_version': 0,
+                                 'upgrader_avail': True,
+                                 'version_string': '005.000.000.50106'},
+                  'os_info': {'architecture': 32,
+                              'display_string': 'Windows 7 Ultimate Edition Service Pack 1, 32-bit',
+                              'id': 1,
+                              'major_version': 6,
+                              'minor_version': 1,
+                              'os_type': 1,
+                              'product_type': 1,
+                              'service_pack': 'Service Pack 1',
+                              'suite_mask': 256},
+                  'sensor_info': {'boot_id': 17,
+                                  'build_id': 9,
+                                  'clock_delta': 2654783,
+                                  'computer_dns_name': 'sensor%d' % sensor_id,
+                                  'computer_name': 'sensor%d' % sensor_id,
+                                  'computer_sid': 'S-1-5-21-2002419555-2189168078-3210101973',
+                                  'cookie': 1962833602,
+                                  'display': True,
+                                  'emet_dump_flags': None,
+                                  'emet_exploit_action': None,
+                                  'emet_is_gpo': False,
+                                  'emet_process_count': 0,
+                                  'emet_report_setting': None,
+                                  'emet_telemetry_path': None,
+                                  'emet_version': None,
+                                  'event_log_flush_time': None,
+                                  'group_id': 1,
+                                  'id': sensor_id,
+                                  'last_checkin_time': datetime.datetime(2015, 6, 30, 6, 9, 15, 570570),
+                                  'last_update': datetime.datetime(2015, 6, 30, 6, 9, 18, 170552),
+                                  'license_expiration': datetime.datetime(1990, 1, 1, 0, 0),
+                                  'network_adapters': '192.168.10.241,000c19e962f6|192.168.10.5,000c23b742dc|',
+                                  'network_isolation_enabled': False,
+                                  'next_checkin_time': datetime.datetime(2015, 6, 30, 6, 9, 45, 564598),
+                                  'node_id': 0,
+                                  'notes': None,
+                                  'num_eventlog_bytes': 400,
+                                  'num_storefiles_bytes': 10304408,
+                                  'os_environment_id': 1,
+                                  'parity_host_id': 2,
+                                  'physical_memory_size': 1073209344,
+                                  'power_state': 0,
+                                  'registration_time': datetime.datetime(2015, 1, 23, 15, 39, 54, 911720),
+                                  'restart_queued': False,
+                                  'sensor_health_message': 'Healthy',
+                                  'sensor_health_status': 100,
+                                  'sensor_uptime': 2976455,
+                                  'session_token': 0,
+                                  'supports_2nd_gen_modloads': False,
+                                  'supports_cblr': True,
+                                  'supports_isolation': True,
+                                  'systemvolume_free_size': 49276923904,
+                                  'systemvolume_total_size': 64422408192,
+                                  'uninstall': False,
+                                  'uninstalled': None,
+                                  'uptime': 340776}}
         return sensor
-
 
     def transport(self, debug=False):
         # TODO: multithread this so we have some parallelization
@@ -252,13 +251,15 @@ class Transporter(object):
                     new_feed_ids |= self.update_feeds(doc)
                     self.output_binary_doc(doc)
                 else:
-                    log.warning("Could not retrieve MD5sum %s from source" % md5sum)
+                    log.warning("Could not retrieve the binary MD5 %s referenced in the process with ID: %s"
+                                % (md5sum, proc['unique_id']))
 
             # TODO: right now we don't munge sensor or feed documents
             for sensor in new_sensor_ids:
                 doc = self.input.get_sensor_doc(sensor)
                 if not doc:
-                    log.warning("Could not retrieve sensor info for sensor id %s from source" % sensor)
+                    log.warning("Could not retrieve sensor info for sensor id %s referenced in the process with ID: %s"
+                                % (md5sum, proc['unique_id']))
                     doc = self.generate_fake_sensor(sensor)
 
                 self.output_sensor_info(doc)
@@ -268,7 +269,8 @@ class Transporter(object):
                 if doc:
                     self.output_feed_doc(doc)
                 else:
-                    log.warning("Could not retrieve feed document for id %s from source" % feed)
+                    log.warning("Could not retrieve feed document for id %s referenced in the process with ID: %s"
+                                % (md5sum, proc['unique_id']))
 
             self.output_process_doc(proc)
 
@@ -289,7 +291,8 @@ class CleanseSolrData(object):
     def __init__(self):
         pass
 
-    def munge_document(self, doc_type, doc_content):
+    @staticmethod
+    def munge_document(doc_content):
         doc_content.pop('_version_', None)
 
         for key in doc_content.keys():
@@ -307,26 +310,28 @@ class DataAnonymizer(object):
     def translate(s):
         """
         Super dumb translation for anonymizing strings.
+        :param s: input string
         """
         s_new = ''
         for c in s:
             if c == '\\':
                 s_new += c
             else:
-                c = chr((ord(c)-65 + 13)%26 + 65)
+                c = chr((ord(c)-65 + 13) % 26 + 65)
                 s_new += c
         return s_new
 
-    def anonymize(self, doc):
+    @staticmethod
+    def anonymize(doc):
         hostname = doc.get('hostname', '')
         hostname_new = DataAnonymizer.translate(hostname)
         username = doc.get('username', '')
-        username_new = None
 
         translation_usernames = {}
 
         if len(username) > 0:
-            if username.lower() != 'system' and username.lower() != 'local service' and username.lower() != 'network service':
+            if username.lower() != 'system' and username.lower() != 'local service' and username.lower() != \
+                    'network service':
                 pieces = username.split('\\')
                 for piece in pieces:
                     translation_usernames[piece] = DataAnonymizer.translate(piece)
@@ -355,5 +360,5 @@ class DataAnonymizer(object):
 
         return doc
 
-    def munge_document(self, doc_type, doc_content):
+    def munge_document(self, doc_content):
         return self.anonymize(doc_content)

--- a/cbopensource/tools/eventduplicator/transporter.py
+++ b/cbopensource/tools/eventduplicator/transporter.py
@@ -29,7 +29,7 @@ class Transporter(object):
 
     def output_process_doc(self, doc):
         for munger in self.mungers:
-            doc = munger.munge_document(doc)
+            doc = munger.munge_document('proc', doc)
 
         sys.stdout.write('%-70s\r' % ("Uploading process %s..." % get_process_id(doc)))
         sys.stdout.flush()
@@ -38,7 +38,7 @@ class Transporter(object):
 
     def output_feed_doc(self, doc):
         for munger in self.mungers:
-            doc = munger.munge_document(doc)
+            doc = munger.munge_document('feed', doc)
 
         # check if we have seen this feed_id before
         feed_id = doc['feed_id']
@@ -54,7 +54,7 @@ class Transporter(object):
     def output_binary_doc(self, doc):
         for munger in self.mungers:
             # note that the mungers are mutating the data in place, anyway.
-            doc = munger.munge_document(doc)
+            doc = munger.munge_document('binary', doc)
 
         sys.stdout.write('%-70s\r' % ("Uploading binary %s..." % doc['md5']))
         sys.stdout.flush()
@@ -64,7 +64,7 @@ class Transporter(object):
     def output_sensor_info(self, doc):
         for munger in self.mungers:
             # note that the mungers are mutating the data in place, anyway.
-            doc['sensor_info'] = munger.munge_document(doc['sensor_info'])
+            doc['sensor_info'] = munger.munge_document('sensor', doc['sensor_info'])
 
         self.output.output_sensor_info(doc)
 
@@ -292,7 +292,7 @@ class CleanseSolrData(object):
         pass
 
     @staticmethod
-    def munge_document(doc_content):
+    def munge_document(doc_type, doc_content):
         doc_content.pop('_version_', None)
 
         for key in doc_content.keys():
@@ -360,5 +360,5 @@ class DataAnonymizer(object):
 
         return doc
 
-    def munge_document(self, doc_content):
+    def munge_document(self, doc_type, doc_content):
         return self.anonymize(doc_content)

--- a/cbopensource/tools/eventduplicator/utils.py
+++ b/cbopensource/tools/eventduplicator/utils.py
@@ -1,13 +1,16 @@
-__author__ = 'jgarman'
-
+from __future__ import absolute_import, division, print_function
 import datetime
 import json
 
+__author__ = 'jgarman'
+
+
 def split_process_id(guid):
     if type(guid) == int:
-        return (guid, 1)
+        return guid, 1
 
-    return (guid[:36], guid[37:])
+    return guid[:36], guid[37:]
+
 
 def get_process_id(proc):
     old_style_id = proc.get('id', None)
@@ -19,6 +22,7 @@ def get_process_id(proc):
             return None
         return new_style_id
 
+
 def get_parent_process_id(proc):
     old_style_id = proc.get('parent_unique_id', None)
     if old_style_id and old_style_id != '':
@@ -29,6 +33,7 @@ def get_parent_process_id(proc):
             return None
         return int(new_style_id)
 
+
 def json_encode(d):
     def default(o):
         if type(o) is datetime.date or type(o) is datetime.datetime:
@@ -36,9 +41,11 @@ def json_encode(d):
 
     return json.dumps(d, default=default)
 
+
 def replace_sensor_in_guid(guid, new_id):
     # first eight characters of the GUID is the sensor ID
     return '%08x-%s' % (new_id, guid[9:])
+
 
 def update_sensor_id_refs(proc, new_id):
     # this function will mutate proc in-place
@@ -55,6 +62,7 @@ def update_sensor_id_refs(proc, new_id):
         proc['unique_id'] = new_unique_id
 
     return proc
+
 
 def update_feed_id_refs(feed_data, new_id):
     # this function will mutate feed in-place

--- a/setup.py
+++ b/setup.py
@@ -2,22 +2,20 @@ from setuptools import setup
 
 setup(
     name='cb-event-duplicator',
-    version='1.1.3',
+    version='1.2.0',
     packages=['cbopensource', 'cbopensource.tools', 'cbopensource.tools.eventduplicator'],
     url='https://github.com/carbonblack/cb-event-duplicator',
     license='MIT',
     author='Bit9 + Carbon Black Developer Network',
     author_email='dev-support@bit9.com',
-    description=
-        'Extract events from one Carbon Black server and send them to another server - useful for demo/testing purposes',
+    description='Extract events from one Carbon Black server and send them to another server ' +
+                '- useful for demo/testing purposes',
     install_requires=[
-        'psycopg2',
-        'requests'
+        'requests==2.9.1',
+        'paramiko==1.16.0',
+        'psycopg2==2.6.1'
     ],
-    extras_require= {
-        'ssh': ['paramiko']
-    },
-    entry_points = {
+    entry_points={
         'console_scripts': ['cb-event-duplicator=cbopensource.tools.eventduplicator.data_migration:main']
     },
     classifiers=[
@@ -27,14 +25,15 @@ setup(
         'Intended Audience :: Developers',
 
         # Pick your license as you wish (should match "license" above)
-         'License :: OSI Approved :: MIT License',
+        'License :: OSI Approved :: MIT License',
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5',
     ],
-    keywords='carbonblack bit9',
+    keywords='carbonblack',
 
 )

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ setup(
     description='Extract events from one Carbon Black server and send them to another server ' +
                 '- useful for demo/testing purposes',
     install_requires=[
-        'requests==2.9.1',
-        'paramiko==1.16.0',
+        'requests==2.7.0',
+        'paramiko==1.15.2',
         'psycopg2==2.6.1'
     ],
     entry_points={


### PR DESCRIPTION
Jason, here are the updates: 

- added support for Python3 without (hopefully) breaking anything for Python 2.7x, I tested it against 2.7.5 on CentOS 7.x
- Updated the README
- Made some minor changes to the SSH client
- Made cb-event-duplicator importable as a module
- Made PEP8 conformant updates where possible
- bumped the version number to 1.2.0 but this will need to be updated in the download links when you've spun up a new binary

BTW, I'm happy to test that out to make sure I haven't broken anything there.